### PR TITLE
Fixed Typo in SDK name

### DIFF
--- a/setup_qemu_ubuntu.html
+++ b/setup_qemu_ubuntu.html
@@ -2099,11 +2099,11 @@
 <h3 id="install-the-sdk-on-the-qemu-virtual-machine">Install the SDK on the QEMU Virtual Machine<a class="headerlink" href="#install-the-sdk-on-the-qemu-virtual-machine" title="Permanent link">&para;</a></h3>
 <p>Download the ctrlX AUTOMATION SDK archive from <a href="https://github.com/boschrexroth/ctrlx-automation-sdk/releases">github boschrexroth/ctrlx-automation-sdk/releases</a> to your VM.</p>
 <p>Here e.g. version 1.12.0:</p>
-<div class="codehilite"><pre><span></span><code><span class="n">wget</span> <span class="n">https</span><span class="p">:</span><span class="o">//</span><span class="n">github</span><span class="o">.</span><span class="n">com</span><span class="o">/</span><span class="n">boschrexroth</span><span class="o">/</span><span class="n">ctrlx</span><span class="o">-</span><span class="n">automation</span><span class="o">-</span><span class="n">sdk</span><span class="o">/</span><span class="n">releases</span><span class="o">/</span><span class="n">download</span><span class="o">/</span><span class="mf">1.12</span><span class="o">.</span><span class="mi">0</span><span class="o">/</span><span class="n">ctrlx</span><span class="o">-</span><span class="n">automation</span><span class="o">-</span><span class="n">sdk</span><span class="o">-</span><span class="mf">1.12</span><span class="o">.</span><span class="mf">0.</span><span class="n">zip</span>
+<div class="codehilite"><pre><span></span><code><span class="n">wget</span> <span class="n">https</span><span class="p">:</span><span class="o">//</span><span class="n">github</span><span class="o">.</span><span class="n">com</span><span class="o">/</span><span class="n">boschrexroth</span><span class="o">/</span><span class="n">ctrlx</span><span class="o">-</span><span class="n">automation</span><span class="o">-</span><span class="n">sdk</span><span class="o">/</span><span class="n">releases</span><span class="o">/</span><span class="n">download</span><span class="o">/</span><span class="mf">1.12</span><span class="o">.</span><span class="mi">0</span><span class="o">/</span><span class="n">ctrlx</span><span class="o">-</span><span class="n">automation</span><span class="o">-</span><span class="n">sdk</span><span class="o">.</span><span class="mf">1.12</span><span class="o">.</span><span class="mf">0.</span><span class="n">zip</span>
 </code></pre></div>
 
 <p>Extract this archive:</p>
-<div class="codehilite"><pre><span></span><code>unzip -XK ctrlx-automation-sdk-1.12.0.zip
+<div class="codehilite"><pre><span></span><code>unzip -XK ctrlx-automation-sdk.1.12.0.zip
 </code></pre></div>
 
 <h3 id="qemu-virtual-machine-networking">QEMU Virtual Machine Networking<a class="headerlink" href="#qemu-virtual-machine-networking" title="Permanent link">&para;</a></h3>


### PR DESCRIPTION
Fixed Typo in the SDK name:
- updated wget command
- updated archive extraction command