### PR TITLE
Update tasks.json

### DIFF
--- a/samples-cpp/datalayer.register.node/.vscode/tasks.json
+++ b/samples-cpp/datalayer.register.node/.vscode/tasks.json
@@ -33,7 +33,7 @@
       "label": "Launch Remote GDB Server",
       "type": "shell",
       "problemMatcher": "$gcc",
-      "command": "ssh ${input:Root-User}@${input:Target-IP}  \"sudo snap run --experimental-gdbserver=:12345 registernode.registerNode\" ",
+      "command": "ssh ${input:Root-User}@${input:Target-IP}  \"sudo snap run --experimental-gdbserver=:12345 cpp-sdk-registernode.registerNode\" ",
     },
   ],
   "inputs": [


### PR DESCRIPTION
The name of the snap is "capp-sdk-registernode" and not "registernode" - executing the task "Launch Remote GDB Server" with the current given command leads to the following error:
rexroot@VirtualControl-1:/snap$ sudo snap run --experimental-gdbserver=:12345 registernode.registerNode
error: cannot find current revision for snap registernode: readlink /snap/registernode/current: no such file or directory