### PR TITLE
use latest available dedicated package versions (removed caret)

### DIFF
--- a/samples-node/datalayer.client.browse/package.json
+++ b/samples-node/datalayer.client.browse/package.json
@@ -18,8 +18,8 @@
         "ts-node": "^10.6.0"
     },
     "dependencies": {
-        "ctrlx-datalayer": "1.3.4",
-        "ctrlx-datalayer-flatbuffers": "1.14.4"
+        "ctrlx-datalayer": "^1.3.4",
+        "ctrlx-datalayer-flatbuffers": "^1.14.4"
     },
     "scripts": {
         "prepare": "npm run tsc",

--- a/samples-node/datalayer.client.browse/package.json
+++ b/samples-node/datalayer.client.browse/package.json
@@ -18,8 +18,8 @@
         "ts-node": "^10.6.0"
     },
     "dependencies": {
-        "ctrlx-datalayer": "^1.3.3",
-        "ctrlx-datalayer-flatbuffers": "^1.14.3"
+        "ctrlx-datalayer": "1.3.4",
+        "ctrlx-datalayer-flatbuffers": "1.14.4"
     },
     "scripts": {
         "prepare": "npm run tsc",

--- a/samples-node/datalayer.client/package.json
+++ b/samples-node/datalayer.client/package.json
@@ -18,8 +18,8 @@
         "ts-node": "^10.6.0"
     },
     "dependencies": {
-        "ctrlx-datalayer": "1.3.4",
-        "ctrlx-datalayer-flatbuffers": "1.14.4"
+        "ctrlx-datalayer": "^1.3.4",
+        "ctrlx-datalayer-flatbuffers": "^1.14.4"
     },
     "scripts": {
         "prepare": "npm run tsc",

--- a/samples-node/datalayer.client/package.json
+++ b/samples-node/datalayer.client/package.json
@@ -18,8 +18,8 @@
         "ts-node": "^10.6.0"
     },
     "dependencies": {
-        "ctrlx-datalayer": "^1.3.3",
-        "ctrlx-datalayer-flatbuffers": "^1.14.3"
+        "ctrlx-datalayer": "1.3.4",
+        "ctrlx-datalayer-flatbuffers": "1.14.4"
     },
     "scripts": {
         "prepare": "npm run tsc",

--- a/samples-node/datalayer.provider.alldata/package.json
+++ b/samples-node/datalayer.provider.alldata/package.json
@@ -18,8 +18,8 @@
         "ts-node": "^10.6.0"
     },
     "dependencies": {
-        "ctrlx-datalayer": "^1.3.3",
-        "ctrlx-datalayer-flatbuffers": "^1.14.3"
+        "ctrlx-datalayer": "1.3.4",
+        "ctrlx-datalayer-flatbuffers": "1.14.4"
     },
     "scripts": {
         "prepare": "npm run copy-bfbs && npm run tsc",

--- a/samples-node/datalayer.provider.alldata/package.json
+++ b/samples-node/datalayer.provider.alldata/package.json
@@ -18,8 +18,8 @@
         "ts-node": "^10.6.0"
     },
     "dependencies": {
-        "ctrlx-datalayer": "1.3.4",
-        "ctrlx-datalayer-flatbuffers": "1.14.4"
+        "ctrlx-datalayer": "^1.3.4",
+        "ctrlx-datalayer-flatbuffers": "^1.14.4"
     },
     "scripts": {
         "prepare": "npm run copy-bfbs && npm run tsc",

--- a/samples-node/datalayer.provider/package.json
+++ b/samples-node/datalayer.provider/package.json
@@ -18,8 +18,8 @@
         "ts-node": "^10.6.0"
     },
     "dependencies": {
-        "ctrlx-datalayer": "^1.3.3",
-        "ctrlx-datalayer-flatbuffers": "^1.14.3"
+        "ctrlx-datalayer": "1.3.4",
+        "ctrlx-datalayer-flatbuffers": "^1.14.4"
     },
     "scripts": {
         "prepare": "npm run copy-bfbs && npm run tsc",

--- a/samples-node/datalayer.provider/package.json
+++ b/samples-node/datalayer.provider/package.json
@@ -18,7 +18,7 @@
         "ts-node": "^10.6.0"
     },
     "dependencies": {
-        "ctrlx-datalayer": "1.3.4",
+        "ctrlx-datalayer": "^1.3.4",
         "ctrlx-datalayer-flatbuffers": "^1.14.4"
     },
     "scripts": {


### PR DESCRIPTION
this prevents also any unwanted node-gyp prebuild which may fail