### PR TITLE
Update install-ctrlx-datalayer.sh

### DIFF
--- a/scripts/install-ctrlx-datalayer.sh
+++ b/scripts/install-ctrlx-datalayer.sh
@@ -5,6 +5,7 @@ set -e
 
 DIR=$1
 if [ ! -z "$DIR" ]; then
+    mkdir -p "$DIR"
     cd $DIR
 fi
 


### PR DESCRIPTION
When run `./ctrlx-automation-sdk/scripts/install-ctrlx-datalayer.sh ctrlx-automation-sdk/deb` as described in readme, it fails since there is no folder created. The fix creates that folder if it does not exists.